### PR TITLE
🔧 Prevent MPD from disconnecting listeners when playback stops

### DIFF
--- a/mpd/root/etc/s6-overlay/s6-rc.d/mpd/run
+++ b/mpd/root/etc/s6-overlay/s6-rc.d/mpd/run
@@ -42,6 +42,7 @@ else
 			name		"HTTPd Output" \n 
 			port		"8000" \n
 			bitrate		"192" \n
+			always_on	"yes" \n
 		}' >> /etc/mpd.conf
 		bashio::log.info 'HTTPd output enabled'
 	fi


### PR DESCRIPTION
As suggested by in https://github.com/Poeschl-HomeAssistant-Addons/mpd/issues/5#issuecomment-2585120789

I think it makes sense as a default for HA.